### PR TITLE
Use public api migration checking interface

### DIFF
--- a/lib/dbcode.rb
+++ b/lib/dbcode.rb
@@ -37,7 +37,11 @@ module DBCode
     code = Schema.new connection: Base.connection, name: code_schema_name
     code.append_path!(Base.connection_config)
 
-    return if Migrator.needs_migration?
+    begin
+      Migration.check_pending!
+    rescue PendingMigrationError
+      return
+    end
 
     code.within_schema do
       graph = build_graph

--- a/spec/dbcode_spec.rb
+++ b/spec/dbcode_spec.rb
@@ -106,9 +106,9 @@ describe 'dbcode' do
   end
 
   describe 'when there are pending migrations' do
-    before {
-      allow(ActiveRecord::Migrator).to receive(:needs_migration?) { true }
-    }
+    before do
+      allow(ActiveRecord::Migrator).to receive(:check_pending!).and_raise(ActiveRecord::PendingMigrationError)
+    end
 
     it 'does not reset out of date schemas' do
       DBCode.prepare


### PR DESCRIPTION
This private migration api was changed at some point. Let's use the documented method instead.